### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ file (look in `/etc/NetworkManager/system-connections`) then converting that to 
 attributes like so:
 
 ```nix
-# configuration.nix
+# /etc/nixos/configuration.nix
 
 { ... }: {
 
-  imports = [ 
+  imports = [
     (import (builtins.fetchTarball https://github.com/jmackie/nixos-networkmanager-profiles/archive/master.tar.gz))
   ];
 
-  config.networking.networkmanager.profiles = {
-    "home-wifi" = { 
+  networking.networkmanager.profiles = {
+    "home-wifi" = {
       connection = {
         id = "home-wifi";
         uuid = "<your-uuid-here>";
@@ -50,4 +50,3 @@ attributes like so:
   };
 }
 ```
-

--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,10 @@ in {
   options.networking.networkmanager.profiles = mkOption {
     type = types.attrs;
     default = { };
+    description = ''
+    A set of network-manager profiles. Can be derived from any *.nmconnection file.
+    For an example, see https://github.com/jmackie/nixos-networkmanager-profiles/blob/master/master/README.md
+    '';
   };
 
   config = mkIf (attrLength nm.profiles > 0) {


### PR DESCRIPTION
Two small things:

  1. Fix the README, there was an extra `configuration` that was misleading
  1. Add a `description` to the `profiles` attribute, so `nixos-option networking.networkmanager.profiles` doesn't crash